### PR TITLE
Small code cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,12 @@ matrix:
   # - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16
   #   compiler: ": #GHC 7.6.3"
   #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18
-    compiler: ": #GHC 7.8.4"
-    addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22
-    compiler: ": #GHC 7.10.3"
-    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18
+  #   compiler: ": #GHC 7.8.4"
+  #   addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22
+  #   compiler: ": #GHC 7.10.3"
+  #   addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
 
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.
@@ -55,9 +55,9 @@ matrix:
 
   # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
-  - env: BUILD=stack ARGS="--resolver lts-2"
-    compiler: ": #stack 7.8.4"
-    addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
+  # - env: BUILD=stack ARGS="--resolver lts-2"
+  #   compiler: ": #stack 7.8.4"
+  #   addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
 
   - env: BUILD=stack ARGS="--resolver lts-3"
     compiler: ": #stack 7.10.2"
@@ -77,9 +77,9 @@ matrix:
     addons: {apt: {packages: [libgmp-dev]}}
 
   # Build on OS X in addition to Linux
-  - env: BUILD=stack ARGS="--resolver lts-2"
-    compiler: ": #stack 7.8.4 osx"
-    os: osx
+  # - env: BUILD=stack ARGS="--resolver lts-2"
+  #   compiler: ": #stack 7.8.4 osx"
+  #   os: osx
 
   - env: BUILD=stack ARGS="--resolver lts-3"
     compiler: ": #stack 7.10.2 osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,9 @@ before_install:
   else
     curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   fi
+- npm --version
+- npm install -g npm@'>=2.13.0'
+- npm --version
 
 install:
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
@@ -134,9 +137,15 @@ install:
       cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS
       ;;
   esac
+  cd app/
+  npm install --dev
+  cd ../
 
 script:
 - |
+  cd app/
+  npm run build-js
+  cd ../
   case "$BUILD" in
     stack)
       stack --no-terminal $ARGS test --haddock --no-haddock-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,154 @@
+# Copy these contents into the root directory of your Github project in a file
+# named .travis.yml
+
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Choose a lightweight base image; we provide our own build tools.
+language: c
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.ghc
+  - $HOME/.cabal
+  - $HOME/.stack
+
+# The different configurations we want to test. We have BUILD=cabal which uses
+# cabal-install, and BUILD=stack which uses Stack. More documentation on each
+# of those below.
+#
+# We set the compiler values here to tell Travis to use a different
+# cache file per set of arguments.
+#
+# If you need to have different apt packages for each combination in the
+# matrix, you can use a line such as:
+#     addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
+matrix:
+  include:
+  # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
+  # https://github.com/hvr/multi-ghc-travis
+  # - env: BUILD=cabal GHCVER=7.0.4 CABALVER=1.16
+  #   compiler: ": #GHC 7.0.4"
+  #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.2.2 CABALVER=1.16
+  #   compiler: ": #GHC 7.2.2"
+  #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.2], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.4.2 CABALVER=1.16
+  #   compiler: ": #GHC 7.4.2"
+  #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16
+  #   compiler: ": #GHC 7.6.3"
+  #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18
+    compiler: ": #GHC 7.8.4"
+    addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22
+    compiler: ": #GHC 7.10.3"
+    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+
+  # Build with the newest GHC and cabal-install. This is an accepted failure,
+  # see below.
+  - env: BUILD=cabal GHCVER=head  CABALVER=head
+    compiler: ": #GHC HEAD"
+    addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+
+  # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
+  # variable, such as using --stack-yaml to point to a different file.
+  - env: BUILD=stack ARGS="--resolver lts-2"
+    compiler: ": #stack 7.8.4"
+    addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-3"
+    compiler: ": #stack 7.10.2"
+    addons: {apt: {packages: [ghc-7.10.2], sources: [hvr-ghc]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-5"
+    compiler: ": #stack 7.10.3"
+    addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-6"
+    compiler: ": #stack 7.10.3"
+    addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+
+  # Nightly builds are allowed to fail
+  - env: BUILD=stack ARGS="--resolver nightly"
+    compiler: ": #stack nightly"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  # Build on OS X in addition to Linux
+  - env: BUILD=stack ARGS="--resolver lts-2"
+    compiler: ": #stack 7.8.4 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-3"
+    compiler: ": #stack 7.10.2 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-5"
+    compiler: ": #stack 7.10.3 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-6"
+    compiler: ": #stack 7.10.3 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver nightly"
+    compiler: ": #stack nightly osx"
+    os: osx
+
+  allow_failures:
+  - env: BUILD=cabal GHCVER=head  CABALVER=head
+  - env: BUILD=stack ARGS="--resolver nightly"
+
+before_install:
+# Using compiler above sets CC to an invalid value, so unset it
+- unset CC
+
+# We want to always allow newer versions of packages when building on GHC HEAD
+- CABALARGS=""
+- if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
+
+# Download and unpack the stack executable
+- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$PATH
+- mkdir -p ~/.local/bin
+- |
+  if [ `uname` = "Darwin" ]
+  then
+    curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  else
+    curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  fi
+
+install:
+- echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+- if [ -f configure.ac ]; then autoreconf -i; fi
+- |
+  case "$BUILD" in
+    stack)
+      stack --no-terminal --install-ghc $ARGS test --only-dependencies
+      ;;
+    cabal)
+      cabal --version
+      travis_retry cabal update
+      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS
+      ;;
+  esac
+
+script:
+- |
+  case "$BUILD" in
+    stack)
+      stack --no-terminal $ARGS test --haddock --no-haddock-deps
+      ;;
+    cabal)
+      cabal configure --enable-tests --enable-benchmarks -v2 --ghc-options="-O0 -Wall"
+      cabal build
+      cabal check || [ "$CABALVER" == "1.16" ]
+      cabal test
+      cabal sdist
+      cabal copy
+      SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz && \
+        (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+      ;;
+  esac

--- a/Yesod/JobQueue/GenericConstr.hs
+++ b/Yesod/JobQueue/GenericConstr.hs
@@ -1,13 +1,8 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE TypeOperators #-}
 module Yesod.JobQueue.GenericConstr where
 
-import GHC.Generics
 import Data.Proxy
 import Data.Typeable
+import GHC.Generics
 
 -- *Demo> genericConstructors  (Proxy :: Proxy (Either Int Bool))
 -- [["Left","Int"],["Right","Bool"]]
@@ -49,4 +44,3 @@ instance (Fields f, Fields g) => Fields (f :*: g) where
 
 instance Typeable a => Fields (K1 i a) where
   fields _ = [show (typeRep (Proxy :: Proxy a))]
-  

--- a/Yesod/JobQueue/Routes.hs
+++ b/Yesod/JobQueue/Routes.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
 module Yesod.JobQueue.Routes where
 
-import Yesod
 import Data.Text
+import Yesod
 
 -- Subsites have foundations just like master sites.
 data JobQueue = JobQueue

--- a/Yesod/JobQueue/Scheduler.hs
+++ b/Yesod/JobQueue/Scheduler.hs
@@ -1,14 +1,14 @@
 -- | Cron Job for Yesod
 module Yesod.JobQueue.Scheduler where
 
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Control (MonadBaseControl)
+import Data.Monoid ((<>))
+import qualified Data.Text as T (pack)
+import System.Cron.Schedule
 import Yesod.JobQueue
 import Yesod.JobQueue.Types
-import System.Cron.Schedule
 
-import qualified Prelude as P
-import ClassyPrelude.Yesod
-
-import qualified Data.Text as T (pack)
 
 -- | Cron Scheduler for YesodJobQueue
 class (YesodJobQueue master) => YesodJobQueueScheduler master where
@@ -20,9 +20,9 @@ class (YesodJobQueue master) => YesodJobQueueScheduler master where
     startJobSchedule master = do
         let add (s, jt) = addJob (enqueue master jt) s
         tids <- liftIO $ execSchedule $ mapM_ add $ getJobSchedules master
-        print tids
+        liftIO $ print tids
 
 -- | Need by 'getClassInformation'
 schedulerInfo :: YesodJobQueueScheduler master => master ->  JobQueueClassInfo
 schedulerInfo m = JobQueueClassInfo "Scheduler" $  map (T.pack . showSchedule) $ getJobSchedules m
-  where showSchedule (s, jt) = s ++ " | " ++ (show jt)
+  where showSchedule (s, jt) = s <> " | " <> (show jt)

--- a/Yesod/JobQueue/Types.hs
+++ b/Yesod/JobQueue/Types.hs
@@ -1,8 +1,10 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module Yesod.JobQueue.Types where
 
-import ClassyPrelude.Yesod
 import Data.Aeson.APIFieldJsonTH
-import Control.Lens
+import Data.Text (Text)
+import Control.Lens (makeFields)
 
 data PostJobQueueRequest = PostJobQueueRequest {
     _postJobQueueRequestJob :: String

--- a/yesod-job-queue.cabal
+++ b/yesod-job-queue.cabal
@@ -27,36 +27,41 @@ flag example
                               
 library
   exposed-modules:     Yesod.JobQueue
+                     , Yesod.JobQueue.GenericConstr
+                     , Yesod.JobQueue.Routes
                      , Yesod.JobQueue.Scheduler
                      , Yesod.JobQueue.Types
-                     , Yesod.JobQueue.Routes
-                     , Yesod.JobQueue.GenericConstr
-  default-extensions:  TemplateHaskell
-                     , MultiParamTypeClasses
-                     , FunctionalDependencies
-                     , TypeSynonymInstances
+  default-extensions:  FlexibleContexts
                      , FlexibleInstances
-                     , QuasiQuotes
-                     , TypeFamilies
+                     , FunctionalDependencies
+                     , KindSignatures
+                     , MultiParamTypeClasses
                      , OverloadedStrings
-                     , FlexibleContexts
+                     , ScopedTypeVariables
+                     , TypeFamilies
+                     , TypeOperators
+                     , TypeSynonymInstances
                      , ViewPatterns
   build-depends:       base >= 4.7 && < 5
-                     , stm
-                     , hedis
-                     , uuid
                      , aeson
-                     , cron
-                     , monad-logger
-                     , bytestring
-                     , lens
-                     , classy-prelude-yesod
                      , api-field-json-th
-                     , yesod >= 1.4 && < 1.5
+                     , bytestring
+                     , cron
                      , file-embed
+                     , hedis
+                     , lens
+                     , monad-control
+                     , monad-logger
+                     , stm
                      , text
                      , time
+                     , transformers
+                     , uuid
+                     , yesod >= 1.4 && < 1.5
+                     , yesod-core
+                     , yesod-persistent
                      
+  ghc-options:         -Wall -fwarn-tabs -O2
   default-language:    Haskell2010
 
 executable          yesod-job-queue-example


### PR DESCRIPTION
This is just a small code cleanup.

Here are the main things I've changed:
- Add a `.travis.yml`.  You'll have to go to https://travis-ci.org/nakaji-dayo/yesod-job-queue to enable travis for this repo.  I enabled travis for my fork to test that it works.  You can see it [here](https://travis-ci.org/cdepillabout/yesod-job-queue).
  - It's testing lts-3, lts-5 and lts-6.  If you want additional targets, we can update the `.travis.yml` in a future pull-request.
- Remove the dependency on `classy-prelude-yesod`.
  - It's generally good style for a library not to depend on `classy-prelude`.  It makes the import lists at the top of each module longer, but it reduces the dependencies for the library.
- Make all imports either explicit or qualified.  This makes the code easier to read through.
- Break-up the `startThread` function to make it a little simpler to read.
