### PR TITLE
Generalize enqueue (and some other cleanup)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,10 @@ matrix:
     compiler: ": #stack 7.10.3"
     addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
 
+  - env: BUILD=stack ARGS="--resolver lts-7"
+    compiler: ": #stack 8.0.1"
+    addons: {apt: {packages: [ghc-8.0.1], sources: [hvr-ghc]}}
+
   # Nightly builds are allowed to fail
   - env: BUILD=stack ARGS="--resolver nightly"
     compiler: ": #stack nightly"
@@ -91,6 +95,10 @@ matrix:
 
   - env: BUILD=stack ARGS="--resolver lts-6"
     compiler: ": #stack 7.10.3 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-7"
+    compiler: ": #stack 8.0.1 osx"
     os: osx
 
   - env: BUILD=stack ARGS="--resolver nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,10 @@ matrix:
     compiler: ": #stack 7.10.3"
     addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-7"
-    compiler: ": #stack 8.0.1"
-    addons: {apt: {packages: [ghc-8.0.1], sources: [hvr-ghc]}}
+  # Disable because of https://github.com/haskell/haddock/issues/508
+  # - env: BUILD=stack ARGS="--resolver lts-7"
+  #   compiler: ": #stack 8.0.1"
+  #   addons: {apt: {packages: [ghc-8.0.1], sources: [hvr-ghc]}}
 
   # Nightly builds are allowed to fail
   - env: BUILD=stack ARGS="--resolver nightly"
@@ -97,9 +98,10 @@ matrix:
     compiler: ": #stack 7.10.3 osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-7"
-    compiler: ": #stack 8.0.1 osx"
-    os: osx
+  # Disable because of https://github.com/haskell/haddock/issues/508
+  # - env: BUILD=stack ARGS="--resolver lts-7"
+  #   compiler: ": #stack 8.0.1 osx"
+  #   os: osx
 
   - env: BUILD=stack ARGS="--resolver nightly"
     compiler: ": #stack nightly osx"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# yesod-job-queue [![Hackage](https://img.shields.io/hackage/v/yesod-job-queue.svg?maxAge=25920)](https://hackage.haskell.org/package/yesod-job-queue)
-
-Background jobs library for Yesod. 
+# yesod-job-queue [![Hackage](https://img.shields.io/hackage/v/yesod-job-queue.svg?maxAge=25920)](https://hackage.haskell.org/package/yesod-job-queue) [![Stackage LTS](http://stackage.org/package/yesod-job-queue/badge/lts)](http://stackage.org/lts/package/yesod-job-queue) [![Stackage Nightly](http://stackage.org/package/yesod-job-queue/badge/nightly)](http://stackage.org/nightly/package/yesod-job-queue) [![Build Status](https://secure.travis-ci.org/nakaji-dayo/yesod-job-queue.svg)](http://travis-ci.org/nakaji-dayo/yesod-job-queue)
+Background jobs library for Yesod.
 
 - There are API and Web UI for managing the job.
-- Queue backend is Redis. 
+- Queue backend is Redis.
 - Multithreaded.
 
 
@@ -22,7 +21,7 @@ data App = App {
     , appDBConf :: SqliteConf
     , appJobState :: JobState
     }
-    
+
 -- e.g. In makeFoundation
 main = do
     jobState <- newJobState -- create JobState

--- a/Yesod/JobQueue.hs
+++ b/Yesod/JobQueue.hs
@@ -175,14 +175,14 @@ startThread m tNo = void $ liftIO $ forkIO $ do
         STM.atomically $ STM.modifyTVar (getJobState m) (L.delete runningJob)
 
 -- | Add job to end of the queue
-enqueue :: YesodJobQueue master => master -> JobType master -> IO ()
-enqueue m jt = do
+enqueue :: (MonadIO m, YesodJobQueue master) => master -> JobType master -> m ()
+enqueue m jt = liftIO $ do
     time <- getCurrentTime
     let item = JobQueueItem
             { queueJobType = show jt
             , queueTime = time
             }
-    conn <- liftIO $ R.connect $ queueConnectInfo m
+    conn <- R.connect $ queueConnectInfo m
     void $ R.runRedis conn $ R.rpush (queueKey m) [BSC.pack $ show item]
 
 -- | Get all jobs in the queue

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.12
+resolver: lts-7.2
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/yesod-job-queue.cabal
+++ b/yesod-job-queue.cabal
@@ -18,7 +18,9 @@ maintainer:          nakaji.dayo@gmail.com
 copyright:           2016 Daishi Nakajima
 category:            Web
 build-type:          Custom
-extra-source-files: app/dist/app.bundle.js
+extra-source-files:  README.md
+                     app/dist/app.bundle.js
+                     doc/yesod-job-queue-ss.png
 cabal-version:       >=1.10
 
 flag example


### PR DESCRIPTION
This PR contains the following fixes:
- Generalize the `enqueue` method to `MonadIO` instead of just `IO`.  This makes it easier to call from Yesod `HandlerT` functions.
- Update the stackage lts version from 5.12 to 7.2.  Also add lts-7 as a test target in `.travis.yml`.
- Add `README.md` to the cabal file so it shows up on Hackage.
- Add some additional shields to the `README.md`. 
